### PR TITLE
Upgrade to cson-safe v1.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "dependencies": {
     "fairmont": "^0.7.4",
-    "cson-safe": "^0.1.1"
+    "cson-safe": "^1.0.0"
   },
   "devDependencies": {},
   "scripts": {


### PR DESCRIPTION
The big change in v1.0.0 is that cson-safe now uses coffee-script
instead of -redux for parsing. This leads to less confusing behavior in
the subtle cases where -redux does not match coffee-script behavior. It
also collapses the dependency tree from a gazillion packages down to
one.
